### PR TITLE
Add a basic FormElement config for FormBuilder

### DIFF
--- a/Configuration/NodeTypes.FormElement.Captcha.yaml
+++ b/Configuration/NodeTypes.FormElement.Captcha.yaml
@@ -1,0 +1,7 @@
+'Tms.Hcaptcha:Captcha':
+  superTypes:
+    'Neos.Form.Builder:FormElement': true
+  ui:
+    icon: 'icon-shield'
+    group: 'form.custom'
+    label: 'hCaptcha'


### PR DESCRIPTION
There was no FormElement that I can easily add to my Form. So I added a very basic FormElement Config so that you can add it as a FormElement to your Node-based FormBuilder Form.