### PR TITLE
task: loose neos/form restraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-plugin",
     "description": "hCaptcha form element for Neos.Form",
     "require": {
-        "neos/form": "^4.0 || ^5.0"
+        "neos/form": "^4.0 || ^5.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows version 6 (which uses neos/symfonymailer i.o. neos/swiftmailer).